### PR TITLE
Task 3.5 Context

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,21 +1,22 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
 }
 
 int statelessCount = 0;
 
-class MyApp extends StatelessWidget {
+class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      title: 'Flutter Course App',
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
       home: Scaffold(
         appBar: AppBar(
-          title: Text('Task 3.4 Demo'),
+          title: Text('Task 3.5 Demo'),
         ),
         body: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -36,8 +37,13 @@ class SampleStatelessWidget extends StatelessWidget {
     statelessCount++;
     print('Stateless count: $statelessCount');
     return Center(
-      child: Text('Stateless count: $statelessCount', style: Theme.of(context).textTheme.headline4),
+      child: Text('Stateless count: $statelessCount',
+          style: Theme.of(context).textTheme.headline4),
     );
+  }
+
+  Type returnContextRuntimeType() {
+     // return context.runtimeType;  // Undefined name 'context'.
   }
 }
 
@@ -60,7 +66,12 @@ class _SampleStatefulWidget extends State<SampleStatefulWidget> {
     statefulCount++;
     print('Stateful count: $statefulCount');
     return Center(
-      child: Text('Stateful count: $statefulCount', style: Theme.of(context).textTheme.headline4),
+      child: Text('Stateful count: $statefulCount',
+          style: Theme.of(context).textTheme.headline4),
     );
+  }
+
+  Type returnContextRuntimeType() {
+    return context.runtimeType;
   }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,17 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:places/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('Stateless/Stateful counter smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(App());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that our counters starts at 1.
+    expect(find.text('Stateless count: 1'), findsOneWidget);
+    expect(find.text('Stateful count: 1'), findsOneWidget);
   });
 }


### PR DESCRIPTION
1) Если переименовать через рефактор в Studio то запустится
Если попробовать запустить из терминала то нет - _Target file "lib/main.dart" not found_  
Что бы запустить из терминала можно выполнить _flutter run --target=lib/start.dart_

2) Title
Android: the titles appear above the task manager's app snapshots which are displayed when the user presses the "recent apps" button. 
iOS: this value cannot be used.

3) В StatelessWidget нельзя. контекст доступен только в методе build
4) В StatefulWidget нельзя, контекст доступен только в методе build, но можно в его стейте